### PR TITLE
Make comment in config.yml correct

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -45,7 +45,7 @@ hooks-options:
     use-lands: false
 
 explosive-options:
-  # If this is enabled blocks will not be effected by explosions.
+  # If this is disabled blocks will not be effected by explosions.
   block-damage: true
   # When blocks are damaged from explosions, should all effected blocks be tossed in different directions?
   block-physics: true


### PR DESCRIPTION
The comment above block-damage said "If this is enabled blocks will not be effected by explosions.", but the opposite is true. Changed to "If this is disabled blocks will not be effected by explosions."