### PR TITLE
Add world blacklist for tree physics

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -213,6 +213,9 @@ tree-physic-options:
     - "STRIPPED_SPRUCE_LOG:-1"
     - "LOG:-1"
     - "LOG_2:-1"
+    # The worlds inside the list below will be ignored by PTG when looking at tree physics.
+    blacklisted-worlds:
+      - "world_the_end"
 
 block-place-options:
   # If this is enabled PTG will listen when a player places a block and perform effects.

--- a/config_latest.yml
+++ b/config_latest.yml
@@ -213,6 +213,9 @@ tree-physic-options:
     - "STRIPPED_SPRUCE_LOG:-1"
     - "LOG:-1"
     - "LOG_2:-1"
+    # The worlds inside the list below will be ignored by PTG when looking at tree physics.
+    blacklisted-worlds:
+      - "world_the_end"
 
 block-place-options:
   # If this is enabled PTG will listen when a player places a block and perform effects.

--- a/src/XZot1K/plugins/ptg/core/Listeners.java
+++ b/src/XZot1K/plugins/ptg/core/Listeners.java
@@ -119,7 +119,7 @@ public class Listeners implements Listener {
     @SuppressWarnings("deprecation")
     @EventHandler
     public void onBreak(BlockBreakEvent e) {
-        if (plugin.getConfig().getBoolean("tree-physic-options.tree-physics")) {
+        if (plugin.getConfig().getBoolean("tree-physic-options.tree-physics") && !isInList("tree-physic-options.blacklisted-worlds", Objects.requireNonNull(e.getBlock().getWorld()).getName())) {
             if (isInMaterialList("tree-physic-options.effected-break-materials", e.getBlock())) {
                 boolean blockRegeneration = plugin.getConfig().getBoolean("tree-physic-options.tree-regeneration.regeneration");
                 int radius = plugin.getConfig().getInt("tree-physic-options.tree-physics-radius"),


### PR DESCRIPTION
This adds a config option to blacklist the tree physics on specific worlds, bringing it in line with the rest of the configuration.

This is useful on servers that want the tree physics, but have - for example - a creative building world that it shouldn't apply to.